### PR TITLE
Fix 9.1.0-SNAPSHOT builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,10 +87,28 @@ jobs:
           distribution: temurin
           cache: 'maven'
           mvn-toolchain-id: 'JavaSE-17'
+      
+      - name: Set up JDK 21
+        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: 'maven'
+          mvn-toolchain-id: 'JavaSE-21'
+      
+      # Manually install Maven 3.9.9 because ubuntu-latest image uses Maven 3.8.8 by default
+      # https://github.com/actions/setup-java/issues/685#issuecomment-2354724977
+      - name: Install latest Maven
+        run: |
+          MAVEN_VERSION=3.9.9
+          wget https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
+          tar xzvf apache-maven-$MAVEN_VERSION-bin.tar.gz
+          sudo mv apache-maven-$MAVEN_VERSION /opt/maven
+          sudo rm -f /usr/bin/mvn  # Remove existing symbolic link if it exists
+          sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn  # Create new symbolic link
 
       - name: Build & test core libraries
         run: |
-          mvn verify
           mvn install
         working-directory: core
 
@@ -118,19 +136,14 @@ jobs:
           PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         working-directory: agent
 
-      - name: Build
+      - name: Build & test
         run: |
           mvn clean
           mvn p2:site
           mvn jetty:run &
           cd ../../
-          mvn package
+          mvn verify
         working-directory: releng/third-party
-
-      - name: Run Unit Tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
-        with:
-          run: mvn verify
 
       - name: Run UI Tests
         # Ignore UI failures for now


### PR DESCRIPTION
I wanted to download a SNAPSHOT build for 9.1.0 today, but the last successful build was one from September 6th:
https://github.com/adoptium/jmc-build/actions/runs/10743086072

From September 8th onward there was a change in upstream JMC that requires a JavaSE-21 toolchain: https://github.com/adoptium/jmc-build/actions/runs/10762023004/job/29841869257#step:13:16755

This PR sets up that toolchain, and further in the build JMC also requires [Maven 3.9.0+](https://github.com/aptmac/openjdk-jmc-overrides/actions/runs/11668136982/job/32487102695#step:11:28728). The ubuntu-latest image ships with Maven 3.8.8 by default, so 3.9.X has to be manually installed. I've added that as a step here too.

I've also simplified the steps where a maven command was immediately followed up by a command that re-runs the previous. In the case of core: mvn verify -> mvn install, and application: mvn package -> mvn verify, both of these could just be handled by the later command. If you'd like to keep the original runs I can restore them.

Edit: here's a passing GH actions run where I just un-commented the deployment and agent steps: https://github.com/aptmac/openjdk-jmc-overrides/actions/runs/11668640955/job/32488779061#step:12:23301 
