### PR TITLE
Updated Jenkinsfile: Added Slack notifications for build statuses and…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,17 +104,33 @@ pipeline {
         }
         // send a mail on unsuccessful and fixed builds
         unsuccessful { // means unstable || failure || aborted
+        // Email notification
             emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!',
             body: '''Check console output at $BUILD_URL to view the results.''',
             recipientProviders: [culprits(), requestor()]
             //to: 'other.recipient@domain.org'
             archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/TEST-*.xml', followSymlinks: false
+
+            // Slack notification
+            slackSend(
+                channel: '#build-failures',
+                color: 'danger',
+                message: "Build *FAILED* for `${env.JOB_NAME}` - Build #${env.BUILD_NUMBER}\nSee details: ${env.BUILD_URL}"
+            )
         }
         fixed { // back to normal
+            // Email notification
             emailext subject: 'Build $BUILD_STATUS $PROJECT_NAME #$BUILD_NUMBER!',
             body: '''Check console output at $BUILD_URL to view the results.''',
             recipientProviders: [culprits(), requestor()]
             //to: 'other.recipient@domain.org'
+
+            // Slack notification
+            slackSend(
+                channel: '#build-failures',
+                color: 'good',
+                message: "Build *FIXED* for `${env.JOB_NAME}` - Build #${env.BUILD_NUMBER}\nSee details: ${env.BUILD_URL}"
+            )
         }
     }
 }


### PR DESCRIPTION
As per the issue #19 
cc
@reinhapa 
Since this repository uses a Jenkins-based CI (indicated by the presence of a Jenkinsfile), I decided to integrate the notification logic into the Jenkins pipeline instead of leaning towards the approach of using GitHub Actions (which already supports notifications and integrations with both email and Slack) I suggested when asking to be assigned to the issue. 
I believe this approach will be effective though I have not done any builds to confirm the notifications being sent because I didn't see any obvious names of our file in Jenkins, I thought I might need to collaborate with the team or the repository maintainers to confirm how the build was set up in the Jenkins instance.
Thank You!

## KEY CHANGES MADE

- **Added Slack Notifications**: I included Slack notifications for unsuccessful and fixed builds, ensuring visibility of build statuses in the team communication channel.

- **Enhanced Email Notifications**: I made sure the email notifications were retained for both unsuccessful and fixed builds.

